### PR TITLE
feat(release): automate release flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,14 @@ name: Build & Publish Docker Image
 
 on:
   push:
-    tags: [ "v*" ]
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to publish (vX.Y.Z)
+        required: true
+        type: string
 
 jobs:
   build:
@@ -13,8 +20,29 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout code
+      - name: Resolve release tag
+        id: release
+        shell: bash
+        env:
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            tag="$INPUT_RELEASE_TAG"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+
+          if [[ ! "$tag" =~ ^v[0-9] ]]; then
+            echo "Invalid release tag: $tag" >&2
+            exit 1
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release tag
         uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.release.outputs.tag }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -23,17 +51,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
+      - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/ff-iii-toolkit-api
           tags: |
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/heads/main') }}
+            type=raw,value=${{ steps.release.outputs.tag }}
             type=sha
-            type=ref,event=tag
 
-      - name: Build image
+      - name: Build and publish image
         uses: docker/build-push-action@v7
         with:
           push: true

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -1,0 +1,140 @@
+name: Finalize release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: write
+  actions: write
+  pull-requests: write
+
+concurrency:
+  group: finalize-release-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  finalize-release:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure release author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Resolve release version
+        id: version
+        env:
+          RELEASE_BRANCH: ${{ github.event.pull_request.head.ref }}
+        shell: bash
+        run: |
+          version="${RELEASE_BRANCH#release/v}"
+          if [[ -z "$version" || "$version" == "$RELEASE_BRANCH" ]]; then
+            echo "Unable to resolve release version from branch: $RELEASE_BRANCH" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push release tag
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          tag="v${RELEASE_VERSION}"
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "Tag ${tag} already exists locally."
+          else
+            git tag -a "$tag" -m "$tag"
+          fi
+          git push origin "$tag"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          tag="v${RELEASE_VERSION}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "GitHub Release ${tag} already exists."
+          else
+            gh release create "$tag" \
+              --title "$tag" \
+              --generate-notes
+          fi
+
+      - name: Trigger image publishing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh workflow run build.yml \
+            --ref "v${RELEASE_VERSION}" \
+            -f release_tag="v${RELEASE_VERSION}"
+
+      - name: Create main-to-dev sync branch
+        id: sync
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          sync_branch="sync/main-to-dev-v${RELEASE_VERSION}"
+          echo "branch=$sync_branch" >> "$GITHUB_OUTPUT"
+
+          if git ls-remote --exit-code --heads origin "$sync_branch" >/dev/null 2>&1; then
+            echo "Sync branch ${sync_branch} already exists; reusing it."
+            exit 0
+          fi
+
+          git push origin HEAD:"refs/heads/${sync_branch}"
+
+      - name: Ensure main-to-dev pull request
+        id: sync_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          SYNC_BRANCH: ${{ steps.sync.outputs.branch }}
+        shell: bash
+        run: |
+          existing_pr="$(gh pr list \
+            --base dev \
+            --head "$SYNC_BRANCH" \
+            --state open \
+            --json number,url \
+            --jq '.[0] // empty')"
+
+          if [[ -n "$existing_pr" ]]; then
+            pr_number="$(jq -r '.number' <<< "$existing_pr")"
+            pr_url="$(jq -r '.url' <<< "$existing_pr")"
+            echo "Sync PR already exists: $pr_url"
+          else
+            pr_url="$(gh pr create \
+              --base dev \
+              --head "$SYNC_BRANCH" \
+              --title "chore(release): sync v${RELEASE_VERSION} back to dev" \
+              --body "Automated back-merge of released main into dev after v${RELEASE_VERSION}.")"
+            pr_number="${pr_url##*/}"
+            echo "Created sync PR: $pr_url"
+          fi
+
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge for sync pull request
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.sync_pr.outputs.number }}
+        run: |
+          gh pr merge "$PR_NUMBER" --auto --merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,136 @@
+name: Prepare release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release-main
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout complete history
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      - name: Check release state
+        id: state
+        shell: bash
+        run: |
+          current_version="$(uv run --frozen cz version -p)"
+          echo "Current project version: $current_version"
+
+          if ! git rev-parse -q --verify "refs/tags/v${current_version}" >/dev/null; then
+            echo "Current version v${current_version} is not tagged yet; release finalization is pending."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Determine next version
+        if: steps.state.outputs.ready == 'true'
+        id: version
+        shell: bash
+        run: |
+          set +e
+          next_version="$(uv run --frozen cz bump --dry-run --yes --get-next)"
+          status=$?
+          set -e
+
+          if [[ $status -eq 3 || $status -eq 21 ]]; then
+            echo "No releasable Conventional Commit found. Skipping release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ $status -ne 0 ]]; then
+            echo "Commitizen failed with exit code $status" >&2
+            exit "$status"
+          fi
+
+          echo "Next version: $next_version"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          echo "version=$next_version" >> "$GITHUB_OUTPUT"
+
+      - name: Check release branch
+        if: steps.version.outputs.should_release == 'true'
+        id: branch
+        env:
+          RELEASE_BRANCH: release/v${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
+            echo "Release branch $RELEASE_BRANCH already exists; reusing it."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Release branch $RELEASE_BRANCH does not exist yet."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure release author
+        if: steps.version.outputs.should_release == 'true' && steps.branch.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Prepare release commit
+        if: steps.version.outputs.should_release == 'true' && steps.branch.outputs.exists == 'false'
+        run: |
+          uv run cz bump --yes --check-consistency
+          git tag -d "v${{ steps.version.outputs.version }}"
+
+      - name: Push release branch
+        if: steps.version.outputs.should_release == 'true' && steps.branch.outputs.exists == 'false'
+        env:
+          RELEASE_BRANCH: release/v${{ steps.version.outputs.version }}
+        run: |
+          git push origin HEAD:"refs/heads/${RELEASE_BRANCH}"
+
+      - name: Ensure release pull request
+        if: steps.version.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BRANCH: release/v${{ steps.version.outputs.version }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          existing_pr="$(gh pr list \
+            --base main \
+            --head "$RELEASE_BRANCH" \
+            --state open \
+            --json url \
+            --jq '.[0].url // empty')"
+
+          if [[ -n "$existing_pr" ]]; then
+            echo "Release PR already exists: $existing_pr"
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head "$RELEASE_BRANCH" \
+            --title "bump: version $RELEASE_VERSION" \
+            --body "Automated release preparation for v$RELEASE_VERSION.\n\nMerge this PR after required checks pass. After merge, the release finalizer will create the Git tag, GitHub Release, publish the GHCR image, and sync released main back to dev."


### PR DESCRIPTION
Port the proven release flow used in Findog Ledger to this repository.

Changes:
- prepare release PRs automatically after eligible changes reach `main`
- use the existing Commitizen + `uv` version provider to calculate semantic versions
- create versioned `release/vX.Y.Z` branches and keep retries idempotent
- finalize merged release PRs by creating the annotated Git tag and GitHub Release
- explicitly trigger GHCR image publishing for the exact immutable release tag
- sync released `main` back to `dev` through an automated PR
- attempt auto-merge for the sync PR when repository settings allow it
- keep the existing Docker image publishing workflow usable from both tag pushes and explicit release dispatch

Operational note: GitHub Actions must be allowed to create pull requests in repository settings. Auto-merge for the `main -> dev` sync PR is optional and requires `Allow auto-merge` to be enabled; otherwise the sync PR will simply remain for manual merge.