### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default code owner for the repository.
+# This requests a review from @wini83 without making approval mandatory by itself.
+* @wini83


### PR DESCRIPTION
Add a repository-wide CODEOWNERS rule so `@wini83` is automatically requested as reviewer for pull requests.

This does not require approval or block merges by itself; that would require a separate ruleset/branch-protection setting.